### PR TITLE
Support for raw IRCC commands, sending of objects, sending a mix of array/objects

### DIFF
--- a/nodes/bravia-ircc.html
+++ b/nodes/bravia-ircc.html
@@ -65,6 +65,26 @@
 
 <script type="text/x-red" data-help-name="bravia-ircc">
   <p>Sends IRCC codes to a Sony BRAVIA Android TV.</p>
-  <p>The IRCC codes can be specified either in the config or via <b>msg.payload</b>.</p>
-  <p>To send multiple IRCC codes at once specify <b>msg.payload</b> as a comma-delimited string, e.g. <i>Up,Down,Left,Right</i>.</p>
+  <p>The codes can be specified either in the config or via <code>msg.payload</code> as a string, object or array.</p>
+  <p><strong>Examples</strong></p>
+  <p>String - to send sigle or multiple codes at once specify <code>msg.payload</code> as a comma-delimited string, e.g. <code>Up,Down,Left,Right</i>.</code></p>
+  <p>
+    Object - send a single command, specify <code>msg.payload</code> as an object with either a <code>name</code> or <code>value</code> to send raw IRCC commands., eg.
+    <pre>{
+  value: 'AAAAAQAAAAEAAAA0Aw=='
+}</pre>
+  </p>
+  <p>
+    Array - to send multiple codes at once specify <code>msg.payload</code> as an array of strings and/or objects, eg.
+    <pre>[
+  'Up',
+  {
+    name: 'Down'
+  },
+  {
+    value: 'AAAAAQAAAAEAAAA0Aw=='
+  }
+]</pre>
+  </p>
+
 </script>

--- a/nodes/bravia-tv.js
+++ b/nodes/bravia-tv.js
@@ -27,13 +27,22 @@ module.exports = (RED) => {
       return this.bravia[protocol].invoke(method, version, payload);
     }
 
-    sendIRCC(codes) {
+    sendCode(codes) {
       if (!this.bravia) {
         this.node.error('The Sony BRAVIA TV is not configured properly, please check your settings.');
         return;
       }
 
       return this.bravia.send(codes);
+    }
+
+    sendIRCC(ircc) {
+      if (!this.bravia) {
+        this.node.error('The Sony BRAVIA TV is not configured properly, please check your settings.');
+        return;
+      }
+
+      return this.bravia.sendIRCC(ircc);
     }
   }
 


### PR DESCRIPTION
This resolves #1 

Gives the ability to:
* Keeps ability to send IRCC command using the drop down
* Keeps ability to send single command via `msg.payload`
* Keeps ability to send multiple commands as a comma-delimited string via `msg.payload`
* Resolves issue sending multiple commands as array via `msg.payload`. For example

`['Input','VolumeUp']`

* Adds ability to send an object containing a raw IRCC value via `msg.payload`. For example

```
{
    value: 'AAAAAQAAAAEAAAAlAw=='
}
```

* Adds ability to send array of strings/objects via `msg.payload`. For example

```
[
    {
        name: 'VolumeUp'
    },
    {
        name: 'Input', // this would be ignored
        value:'AAAAAQAAAAEAAAAlAw=='
    },
    {
        value:'AAAAAQAAAAEAAAAUAw==' // mute
    }
]
```

Probably not the cleanest way of handling this, but struggled to integrate it without excessive changes.

Here is an example flow which allows testing of all the variations:

```json
[{"id":"1fb55c90.c74913","type":"bravia-ircc","z":"bfe1e7b7.329e58","tv":"1ddd3aa6.23ddd5","ircc":"","name":"TV","x":850,"y":220,"wires":[]},{"id":"63b4d2ea.8c4f5c","type":"inject","z":"bfe1e7b7.329e58","name":"VolumeUp","topic":"","payload":"VolumeUp","payloadType":"str","repeat":"","crontab":"","once":false,"x":120,"y":60,"wires":[["1fb55c90.c74913"]]},{"id":"bdddbb3f.a32f68","type":"function","z":"bfe1e7b7.329e58","name":"Parse","func":"msg.payload = [\n{\n        name: 'VolumeUp'\n    },\n    {\n        name: 'Input',\n        value:'AAAAAQAAAAEAAAAlAw=='\n        \n    }\n];\nreturn msg;","outputs":1,"noerr":0,"x":470,"y":380,"wires":[["1fb55c90.c74913"]]},{"id":"1f1f0384.8b8e5c","type":"inject","z":"bfe1e7b7.329e58","name":"VolumeUp,Input as array","topic":"","payload":"","payloadType":"str","repeat":"","crontab":"","once":false,"x":170,"y":220,"wires":[["b97b4409.0dfc88"]]},{"id":"b97b4409.0dfc88","type":"function","z":"bfe1e7b7.329e58","name":"Parse","func":"msg.payload = ['VolumeUp','Input'];\nreturn msg;","outputs":1,"noerr":0,"x":370,"y":220,"wires":[["1fb55c90.c74913"]]},{"id":"3ea36299.b0694e","type":"inject","z":"bfe1e7b7.329e58","name":"VolumeUp,Input as string","topic":"","payload":"VolumeUp,Input","payloadType":"str","repeat":"","crontab":"","once":false,"x":174.5,"y":142,"wires":[["1fb55c90.c74913"]]},{"id":"20fdd063.b74d2","type":"inject","z":"bfe1e7b7.329e58","name":"Input as object (IRCC)","topic":"","payload":"","payloadType":"str","repeat":"","crontab":"","once":false,"x":160,"y":300,"wires":[["53987608.cfd388"]]},{"id":"53987608.cfd388","type":"function","z":"bfe1e7b7.329e58","name":"Parse","func":"msg.payload = {\n    value: 'AAAAAQAAAAEAAAAlAw=='\n};\n\nreturn msg;","outputs":1,"noerr":0,"x":370,"y":300,"wires":[["1fb55c90.c74913"]]},{"id":"f6dabc2.4079f4","type":"inject","z":"bfe1e7b7.329e58","name":"VolumeUp,Input as array of string/object","topic":"","payload":"","payloadType":"str","repeat":"","crontab":"","once":false,"x":220,"y":380,"wires":[["bdddbb3f.a32f68"]]},{"id":"1ddd3aa6.23ddd5","type":"bravia-tv","z":"","name":"Sony Android 55\"","host":"10.0.10.162","port":"80","psk":"0000"}]
```